### PR TITLE
add .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: build and test with npm
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  npm:
+    name: npm ci, lint, test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          # node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        id: npm-ci
+        run: npm ci
+
+      - name: Check Format
+        id: npm-format-check
+        run: npm run --if-present format:check
+
+      - name: Lint
+        id: npm-lint
+        run: npm run --if-present lint
+
+      - name: Test
+        id: npm-ci-test
+        run: npm run --if-present test

--- a/bin/dzcap.js
+++ b/bin/dzcap.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import 'tsx'
 const cli = await import('../dzcap-cli.ts')
-const argv = process.argv
+const argv = globalThis?.process?.argv
+if (!argv) throw new Error(`unable to determine dzcap cli arguments`, { cause: { argv } })
 await cli.main({ argv })

--- a/dzcap-cli.test.ts
+++ b/dzcap-cli.test.ts
@@ -44,7 +44,7 @@ export class DzcapCliTest {
           `--identity=${identityFile}`,
           `--expires=2099-01-01`,
           `--invocationTarget=${invocationTarget}`,
-          `--allow=FOO`,
+          `--allowedAction=FOO`,
         ]);
       })
       const stdoutText = await new Response(stdout.readable).text()


### PR DESCRIPTION
Motivation:
* while devving https://github.com/gobengo/dzcap/pull/2 , I noticed there were no gh actions running `npm test`, and I'm touching enough code that I'd like to make sure I'm not breaking tests on CI